### PR TITLE
Fix for multiple distributions

### DIFF
--- a/templates/default/distributions.erb
+++ b/templates/default/distributions.erb
@@ -9,5 +9,6 @@ SignWith: <%= node[:reprepro][:pgp_email] %>
 <%   unless @pulls["name"] == dist -%>
 Pull: <%= dist %>
 <%   end -%>
+
 <% end -%>
 


### PR DESCRIPTION
Currently, when running reprepro in a repository configured with multiple distributions, it spits out a  "Second appearance of 'Origin' in the same chunk!" error, because the distributions file does not contain a blank line between chunks.
