### PR TITLE
Require Chef 14+ / Cookstyle fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the reprepro cookbook.
 
+## UNRELEASED
+
+- Require Chef Infra Client 14+ and remove the need for the build-essential cookbook
+- Remove unnecessary long_description metadata from metadata.rb
+- Remove unnecessary recipe metadata from metadata.rb
+
 ## v1.1.0 (2019-08-08)
 
 - Migrate to circleci 2 orb

--- a/README.md
+++ b/README.md
@@ -26,11 +26,10 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Chef
 
-- Chef 13+
+- Chef 14+
 
 ### Cookbooks
 
-- build-essential
 - nginx
 - apache2
 - gpg

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,19 +3,15 @@ maintainer        'Sous Chefs'
 maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs/Configures reprepro for an apt repository'
-long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url        'https://github.com/tas50/reprepro'
 issues_url        'https://github.com/tas50/reprepro/issues'
-chef_version      '>= 13.0'
+chef_version      '>= 14.0'
 version           '1.1.0'
 
 # Doesn't make sense to indicate support for non Debian platforms!
 supports 'ubuntu'
 supports 'debian'
 
-depends 'build-essential', '>= 5.0'
 depends 'apache2', '>= 3.0'
 depends 'nginx', '>= 7.0'
 depends 'gpg'
-
-recipe 'reprepro', 'Installs and configures reprepro for an apt repository'


### PR DESCRIPTION
Remove the dep on build-essential and require Chef 14+ instead

Signed-off-by: Tim Smith <tsmith@chef.io>